### PR TITLE
Docker documentation nit

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ docker compose file for prometheus.
 ```
 git clone https://github.com/256-foundation/Hydra-Pool/
 cd Hydra-Pool
+cd docker
 docker compose up -d
 ```
 


### PR DESCRIPTION
This PR adds a simple 
```
cd docker
```

since the original instructions seemed to miss them. Just noticed this while testing, if you prefer different format, let me know.